### PR TITLE
Refactor SVG helper

### DIFF
--- a/helpers/application_helpers.rb
+++ b/helpers/application_helpers.rb
@@ -17,8 +17,10 @@ module ApplicationHelpers
 
   def svg(name)
     root = Middleman::Application.root
-    file_path = "#{root}/source/images/#{name}.svg"
+    images_path = config[:images_dir]
+    file_path = "#{root}/source/#{images_path}/#{name}.svg"
+
     return File.read(file_path) if File.exists?(file_path)
-    "(not found)"
+    "(SVG not found)"
   end
 end


### PR DESCRIPTION
Instead of hard-coding where SVG's should live, the helper now looks for
SVG's in the images directory set by the user in the Middleman
configuration: `:images_dir`.

Closes https://github.com/thoughtbot/middleman-template/issues/3