### PR TITLE
Remove AccessLint::Ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 
 ## [Unreleased (`master`)][unreleased]
 
-Nothing at the moment.
+### Removed
+
+- AccessLint::Ci has been deprecated and therefore removed from this
+  project. ([#21])
 
 [unreleased]: https://github.com/thoughtbot/middleman-template/compare/v0.2.0...HEAD
+[#21]: https://github.com/thoughtbot/middleman-template/pull/21
 
 ## [0.2.0] - 2017-06-30
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 ruby "2.4.0"
 
-gem "accesslint-ci", "0.2.8"
 gem "bourbon", "~> 5.0.0.beta.8"
 gem "middleman", "~> 4.2"
 gem "middleman-aria_current", "~> 0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    accesslint-ci (0.2.8)
-      rest-client (~> 2.0)
-      thor (~> 0.19)
     activesupport (5.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -25,8 +22,6 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.4)
     contracts (0.13.0)
-    domain_name (0.5.20170223)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -44,8 +39,6 @@ GEM
       concurrent-ruby (~> 1.0)
     hashie (3.5.1)
     htmlcompressor (0.2.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     kramdown (1.13.2)
@@ -98,14 +91,10 @@ GEM
     middleman-minify-html (3.4.1)
       htmlcompressor (~> 0.2.0)
       middleman-core (>= 3.2)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
     minitest (5.10.1)
     neat (2.1.0)
       sass (~> 3.4)
       thor (~> 0.19)
-    netrc (0.11.0)
     padrino-helpers (0.13.3.3)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.3)
@@ -122,10 +111,6 @@ GEM
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     redcarpet (3.4.0)
-    rest-client (2.0.1)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     sass (3.4.24)
     sassc (1.11.2)
       bundler
@@ -139,15 +124,11 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  accesslint-ci (= 0.2.8)
   bourbon (~> 5.0.0.beta.8)
   middleman (~> 4.2)
   middleman-aria_current (~> 0.1)
@@ -163,4 +144,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This template comes with the following features and tools:
 - [An SVG view helper][svg]: Output inline SVG's in your views,
   e.g. `<%= svg("logo") %>`.
 - [CircleCI]: Continuous integration.
-- [AccessLint]: For keeping accessibility issues in check.
 - [Hound]: Comments on style violations in GitHub pull requests.
 - [Segment]: Analytics API.
 
@@ -44,7 +43,6 @@ This template comes with the following features and tools:
   [Redcarpet]: https://github.com/vmg/redcarpet
   [svg]: https://github.com/thoughtbot/middleman-template/blob/master/helpers/application_helpers.rb#L18-L25
   [CircleCI]: https://circleci.com/
-  [AccessLint]: https://accesslint.com/
   [Hound]: https://houndci.com/repos
   [Segment]: https://segment.com/
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,21 +1,3 @@
-general:
-  artifacts:
-    - "tmp"
-
-machine:
-  node:
-    version: 6.1.0
-
-dependencies:
-  post:
-    - npm install -g accesslint-cli
-
-compile:
+test:
   override:
     - bundle exec middleman build --verbose
-
-test:
-  post:
-    - |
-      bundle exec middleman server --daemon --port=4567 --watcher-disable && \
-      bundle exec accesslint-ci scan http://localhost:4567


### PR DESCRIPTION
AccessLint::Ci has been deprecated:
https://github.com/accesslint/accesslint-ci

The project has shifted to a new GitHub App:
https://github.com/apps/accesslint