### PR TITLE
Add sitemap

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,0 +1,1 @@
+URL="http://localhost:4567/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 
 ## [Unreleased (`master`)][unreleased]
 
+### Added
+
+- Added a `sitemap.xml` template. ([#23])
+
 ### Changed
 
 - Swapped the sassc gem for sass. ([#22])
@@ -22,6 +26,7 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 [unreleased]: https://github.com/thoughtbot/middleman-template/compare/v0.2.0...HEAD
 [#21]: https://github.com/thoughtbot/middleman-template/pull/21
 [#22]: https://github.com/thoughtbot/middleman-template/pull/22
+[#23]: https://github.com/thoughtbot/middleman-template/pull/23
 
 ## [0.2.0] - 2017-06-30
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "2.4.0"
 
 gem "bourbon", "~> 5.0.0.beta.8"
+gem "builder", "~> 3.2"
 gem "middleman", "~> 4.2"
 gem "middleman-aria_current", "~> 0.1"
 gem "middleman-autoprefixer", "~> 2.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
     bourbon (5.0.0.beta.8)
       sass (~> 3.4)
       thor (~> 0.19)
+    builder (3.2.3)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -126,6 +127,7 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon (~> 5.0.0.beta.8)
+  builder (~> 3.2)
   middleman (~> 4.2)
   middleman-aria_current (~> 0.1)
   middleman-autoprefixer (~> 2.8)

--- a/bin/setup
+++ b/bin/setup
@@ -8,3 +8,8 @@ set -e
 # Set up Ruby dependencies
 gem install bundler --conservative
 bundle check || bundle install
+
+# Set up development environment config
+if [ ! -f .env ]; then
+  cp .sample.env .env
+fi

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  environment:
+    URL: "http://localhost:4567/"
 test:
   override:
     - bundle exec middleman build --verbose

--- a/config.rb
+++ b/config.rb
@@ -16,9 +16,9 @@ set :markdown,
   with_toc_data: true
 set :markdown_engine, :redcarpet
 
-page "/*.xml", layout: false
 page "/*.json", layout: false
 page "/*.txt", layout: false
+page "/*.xml", layout: false
 
 configure :development do
   activate :livereload do |reload|

--- a/source/sitemap.xml.builder
+++ b/source/sitemap.xml.builder
@@ -1,0 +1,12 @@
+xml.instruct!
+xml.urlset xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" do
+  pages = sitemap.resources.select do |page|
+    page.path =~ /\.html/
+  end
+
+  pages.each do |page|
+    xml.url do
+      xml.loc URI.join(ENV.fetch("URL"), page.url)
+    end
+  end
+end


### PR DESCRIPTION
This builds a proper `sitemap.xml` file at the root of the website. It
aids in SEO, telling search engines about the organization of the site's
content.

https://support.google.com/webmasters/answer/156184

The `URL` environment variable gives us an easy global way of accessing
the site's URL, for use in the sitemap and anywhere else. Netlify
provides some pre-defined variables, including `URL`, which "represents
the main address to your site". Using this means we won't need to set
the variable manually in the Netlify settings.

https://www.netlify.com/docs/continuous-deployment/#build-environment-variables