### PR TITLE
Improve CircleCI configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 ### Changed
 
 - Swapped the sassc gem for sass. ([#22])
+- Improved CircleCI configuration. ([#24])
 
 ### Removed
 
@@ -27,6 +28,7 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 [#21]: https://github.com/thoughtbot/middleman-template/pull/21
 [#22]: https://github.com/thoughtbot/middleman-template/pull/22
 [#23]: https://github.com/thoughtbot/middleman-template/pull/23
+[#24]: https://github.com/thoughtbot/middleman-template/pull/24
 
 ## [0.2.0] - 2017-06-30
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
-machine:
-  environment:
-    URL: "http://localhost:4567/"
-test:
+checkout:
+  post:
+    - cp .sample.env .env
+compile:
   override:
     - bundle exec middleman build --verbose
+test:
+  override:
+    - echo "No tests. See the 'compile' step."


### PR DESCRIPTION
This improves the setup for CircleCI to ensure our "test" runs
effectively and efficiently.

- Add the `checkout` command to copy the sample environment variables
  file into a `.env` file. This ensures CircleCI has the proper
  environment variables when building, and copying the sample files
  allows us to manage them in one place.
- Add the `compile` command to build the static site. CircleCI was
  inferring this command already, but it was not running the build
  command with the `--verbose` flag, which is much more descriptive and
  useful for tracking down any errors and warnings.
- Change the `test` to command to not run any tests. This is a required
  command, so we need to have it, but we aren't actually running a test
  suite (we just want to be sure the site can be built/compiled). Since
  the `compile` command is now handling the building of the site, we can
  just output 'true' here.