### PR TITLE
Improve error-handling of SVG helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 - Update normalize.css from 7.0.0 to 8.0.0
 - Moved to CircleCI 2.0 ([#30])
 - `.sample.env` is now `.env.sample`
+- Improved error-handling of SVG helper ([#29])
 
 ### Removed
 
@@ -29,6 +30,7 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 [unreleased]: https://github.com/thoughtbot/middleman-template/compare/v0.4.0...HEAD
 [asdf]: https://github.com/asdf-vm/asdf
 [#30]: https://github.com/thoughtbot/middleman-template/pull/30
+[#29]: https://github.com/thoughtbot/middleman-template/pull/29
 
 ## [0.4.0] - 2018-02-13
 

--- a/helpers/application_helpers.rb
+++ b/helpers/application_helpers.rb
@@ -21,6 +21,7 @@ module ApplicationHelpers
     file_path = "#{root}/source/#{images_path}/#{name}.svg"
 
     return File.read(file_path) if File.exists?(file_path)
-    "(SVG not found)"
+
+    raise "SVG not found: #{name}"
   end
 end


### PR DESCRIPTION
When an SVG is not found, you'll now be shown a proper error page in the browser.