### PR TITLE
Require file extension when using `svg()` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is loosely based on [Keep a Changelog] and this project adheres to
 - Moved to CircleCI 2.0 ([#30])
 - `.sample.env` is now `.env.sample`
 - Improved error-handling of SVG helper ([#29])
+- The file extension is now required when calling the `svg()` helper,
+  e.g. `<%= svg("foo.svg") %>`
 
 ### Removed
 

--- a/helpers/application_helpers.rb
+++ b/helpers/application_helpers.rb
@@ -18,7 +18,7 @@ module ApplicationHelpers
   def svg(name)
     root = Middleman::Application.root
     images_path = config[:images_dir]
-    file_path = "#{root}/source/#{images_path}/#{name}.svg"
+    file_path = "#{root}/source/#{images_path}/#{name}"
 
     return File.read(file_path) if File.exists?(file_path)
 


### PR DESCRIPTION
This matches how the `inline_svg` gem works for Rails: https://github.com/jamesmartin/inline_svg

Having it mimic Inline SVG makes it easier on developers to move between Middleman and Rails.