### PR TITLE
Run asdf install in setup script

### DIFF
--- a/template/bin/setup
+++ b/template/bin/setup
@@ -5,6 +5,10 @@
 # Exit if any subcommand fails
 set -e
 
+if command -v asdf > /dev/null; then
+  asdf install
+fi
+
 # Set up Ruby dependencies
 gem install bundler --conservative
 bundle check || bundle install


### PR DESCRIPTION
As a consumer of this template, after you run the Middleman command
to initialize a new project, we run the `bin/setup`. However, if you
don't have your Ruby version set to the version we expect, then the
script fails.

Checking for asdf (which is commonly used at thoughtbot) and then
running its `install` command, will that our required Ruby version
is in place while executing the setup script.