### PR TITLE
Update CSS temporary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-template/.tmp
 template/Gemfile.lock
 template/node_modules
 template/package-lock.json
+template/tmp

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -5,3 +5,4 @@
 build/
 netlifyctl-debug.log
 node_modules
+tmp

--- a/template/bin/sass
+++ b/template/bin/sass
@@ -4,7 +4,7 @@ set -e
 
 LOAD_PATH="node_modules"
 INPUT="source/assets/stylesheets"
-OUTPUT=".tmp/assets/stylesheets"
+OUTPUT="tmp/assets/stylesheets"
 
 if [ "$1" = "development" ]; then
   OPTIONS="--watch"

--- a/template/config.rb
+++ b/template/config.rb
@@ -26,7 +26,7 @@ ignore "*.scss"
 activate :external_pipeline,
          name: :sass,
          command: build? ? "bin/sass" : "bin/sass development",
-         source: ".tmp",
+         source: "tmp",
          latency: 1
 
 configure :production do


### PR DESCRIPTION
This commit changes the directory to match with the global `.gitignore`
from dotfiles to avoid tracking compiled CSS files.

* also adds a directory to template's `.gitignore` to serve machines
without dotfiles